### PR TITLE
Update dualluc_scriptV1.r

### DIFF
--- a/dualluc_scriptV1.r
+++ b/dualluc_scriptV1.r
@@ -85,6 +85,14 @@ pdf("FR1.pdf", height=11, width=10)
 grid.table(FR2_tidy2)
 dev.off()
 
+#Attemp to spread the dataframe. However, each row is kept as independent measurement. The goal here is to create a table containing the technical replicates of the experiment.
+FR_tidy4 <- df %>%
+  select(condition, FR) %>%
+  mutate(grouped_id = row_number()) %>%
+  group_by(condition) %>%
+  spread(key = condition, value = FR, fill = FALSE) %>%
+  select(-grouped_id)
+
 #doing the relative calculation i.e. normalize to expression of the empty vector "Ev"
 #Calculate the average of the EV control
 EV_mean <- FR_tidy %>% filter(condition=="Control") %>% summarise(mean_EV_FR=mean(FR))  %>% unlist(use.names = FALSE)


### PR DESCRIPTION
I added a bit to make a table in the wide format so we can create a summary table containing the 4 technical measurements per conditions. So far, I am not able to get a row for each technical replicate... There should be four, instead I get 12. 

This is how I imagine it in the end: 
![afbeelding](https://user-images.githubusercontent.com/52273820/76328606-caf34a80-62eb-11ea-9b24-7178fec357c2.png)